### PR TITLE
initialize go module

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/antihax/optional
+
+go 1.13


### PR DESCRIPTION
With go1.14 and modules as a default on the horizon, now is a great time
to adopt modules. This change adds a go.mod file with the correct import
path and the latest version of the go compiler that will build the code.
The module does not have any dependencies, so there is no go.sum file.

This does enforce use of only one import path, so if gopkg.in or some
other alias is prefered, it should be changed now.

After merge, the repo should be tagged with v1.0.0, unless this module
is not yet stable, in which case the v0.1.0 tag should be used.

Fixes #1.